### PR TITLE
Valideringslogikken må tillate at gjelderId er blank

### DIFF
--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/api/AttestasjonApi.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/api/AttestasjonApi.kt
@@ -20,7 +20,7 @@ fun Route.attestasjonApi(attestasjonService: AttestasjonService = AttestasjonSer
             call.respond(
                 attestasjonService.getOppdrag(
                     gjelderId = request.gjelderId,
-                    fagsystemId = request.fagsystemId,
+                    fagSystemId = request.fagSystemId,
                     kodeFagGruppe = request.kodeFagGruppe,
                     kodeFagOmraade = request.kodeFagOmraade,
                     attestert = request.attestert,

--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/api/model/OppdragsRequest.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/api/model/OppdragsRequest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class OppdragsRequest(
     val gjelderId: String? = null,
-    val fagsystemId: String? = null,
+    val fagSystemId: String? = null,
     val kodeFagGruppe: String? = null,
     val kodeFagOmraade: String? = null,
     val attestert: Boolean? = null,

--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/config/RequestValidationAttestasjonConfig.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/config/RequestValidationAttestasjonConfig.kt
@@ -28,7 +28,7 @@ private fun validateSearchParams(oppdragsRequest: OppdragsRequest): Boolean {
     oppdragsRequest.kodeFagGruppe?.takeIf { oppdragsRequest.attestert == false }?.let { valid = true }
     oppdragsRequest.kodeFagOmraade?.takeIf { oppdragsRequest.attestert == false }?.let { valid = true }
     oppdragsRequest.gjelderId?.let { valid = true }
-    oppdragsRequest.fagsystemId?.let { oppdragsRequest.kodeFagOmraade?.let { valid = true } }
+    oppdragsRequest.fagSystemId?.let { oppdragsRequest.kodeFagOmraade?.let { valid = true } }
 
     return valid
 }

--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/domain/Oppdrag.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/domain/Oppdrag.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Oppdrag(
     val ansvarsSted: String? = null,
-    val fagsystemId: String,
+    val fagSystemId: String,
     val gjelderId: String,
     val kostnadsSted: String,
     val fagGruppe: String,

--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/repository/AttestasjonRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/repository/AttestasjonRepository.kt
@@ -15,7 +15,7 @@ class AttestasjonRepository(
 ) {
     fun getOppdrag(
         gjelderId: String,
-        fagsystemId: String,
+        fagSystemId: String,
         kodeFaggruppe: String,
         kodeFagomraade: String,
         attestert: Boolean?,
@@ -56,7 +56,7 @@ class AttestasjonRepository(
                     """.trimIndent(),
                 )
             if (gjelderId.isNotBlank()) statementParts.add("AND O.OPPDRAG_GJELDER_ID = :GJELDERID")
-            if (fagsystemId.isNotBlank()) statementParts.add("AND O.FAGSYSTEM_ID = :FAGSYSTEMID")
+            if (fagSystemId.isNotBlank()) statementParts.add("AND O.FAGSYSTEM_ID = :FAGSYSTEMID")
             if (kodeFagomraade.isNotBlank()) statementParts.add("AND F.KODE_FAGOMRAADE = :KODEFAGOMRAADE")
             if (kodeFaggruppe.isNotBlank()) statementParts.add("AND G.KODE_FAGGRUPPE = :KODEFAGGRUPPE")
 
@@ -70,13 +70,13 @@ class AttestasjonRepository(
 
             statementParts.add("GROUP BY NAVN_FAGGRUPPE, NAVN_FAGOMRAADE, OPPDRAG_GJELDER_ID, O.OPPDRAGS_ID, FAGSYSTEM_ID, LS.KODE_STATUS, OE.ENHET, LE.ENHET, OEB.ENHET")
             statementParts.add("FETCH FIRST 200 ROWS ONLY")
-            if (gjelderId.isNotBlank() || fagsystemId.isNotBlank()) statementParts.add("OPTIMIZE FOR 1 ROW")
+            if (gjelderId.isNotBlank() || fagSystemId.isNotBlank()) statementParts.add("OPTIMIZE FOR 1 ROW")
             session.list(
                 queryOf(
                     statementParts.joinToString("\n", "", ";"),
                     mapOf(
                         "GJELDERID" to gjelderId,
-                        "FAGSYSTEMID" to fagsystemId,
+                        "FAGSYSTEMID" to fagSystemId,
                         "KODEFAGOMRAADE" to kodeFagomraade,
                         "KODEFAGGRUPPE" to kodeFaggruppe,
                         "ATTESTERT" to attestert,
@@ -194,7 +194,7 @@ class AttestasjonRepository(
     private val mapToOppdrag: (Row) -> Oppdrag = { row ->
         Oppdrag(
             ansvarsSted = row.stringOrNull("ANSVARSSTED"),
-            fagsystemId = row.string("FAGSYSTEM_ID"),
+            fagSystemId = row.string("FAGSYSTEM_ID"),
             gjelderId = row.string("OPPDRAG_GJELDER_ID"),
             kostnadsSted = row.string("KOSTNADSSTED"),
             fagGruppe = row.string("NAVN_FAGGRUPPE"),

--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
@@ -24,7 +24,7 @@ class AttestasjonService(
     fun getOppdrag(
         applicationCall: ApplicationCall,
         attestert: Boolean? = null,
-        fagsystemId: String? = null,
+        fagSystemId: String? = null,
         gjelderId: String? = null,
         kodeFagGruppe: String? = null,
         kodeFagOmraade: String? = null,
@@ -43,7 +43,7 @@ class AttestasjonService(
 
         return attestasjonRepository.getOppdrag(
             gjelderId = gjelderId ?: "",
-            fagsystemId = fagsystemId ?: "",
+            fagSystemId = fagSystemId ?: "",
             kodeFaggruppe = kodeFagGruppe ?: "",
             kodeFagomraade = kodeFagOmraade ?: "",
             attestert = attestert,

--- a/src/main/kotlin/no/nav/sokos/oppdrag/common/util/Util.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/common/util/Util.kt
@@ -2,6 +2,6 @@ package no.nav.sokos.oppdrag.common.util
 
 object Util {
     fun validGjelderId(gjelderId: String): Boolean {
-        return Regex("^(\\d{11}|\\d{9})\$").matches(gjelderId)
+        return gjelderId.isNotEmpty() && Regex("^(\\d{11}|\\d{9})\$").matches(gjelderId)
     }
 }

--- a/src/main/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/domain/Oppdrag.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/domain/Oppdrag.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Oppdrag(
-    val fagsystemId: String,
+    val fagSystemId: String,
     val oppdragsId: Int,
     val navnFagGruppe: String,
     val navnFagOmraade: String,

--- a/src/main/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/repository/OppdragsInfoRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/repository/OppdragsInfoRepository.kt
@@ -576,7 +576,7 @@ class OppdragsInfoRepository(
 
     private val mapToOppdrag: (Row) -> Oppdrag = { row ->
         Oppdrag(
-            fagsystemId = row.string("FAGSYSTEM_ID"),
+            fagSystemId = row.string("FAGSYSTEM_ID"),
             oppdragsId = row.int("OPPDRAGS_ID"),
             navnFagGruppe = row.string("NAVN_FAGGRUPPE"),
             navnFagOmraade = row.string("NAVN_FAGOMRAADE"),

--- a/src/main/resources/openapi/attestasjon-v1-swagger.yaml
+++ b/src/main/resources/openapi/attestasjon-v1-swagger.yaml
@@ -156,7 +156,7 @@ components:
           example: "9 eller 11 siffer"
           description: 9 eller 11 siffer
           nullable: true
-        fagsystemId:
+        fagSystemId:
           type: string
           example: "TU000123456789012"
           nullable: true
@@ -247,7 +247,7 @@ components:
     Oppdrag:
       type: object
       required:
-        - fagsystemId
+        - fagSystemId
         - gjelderId
         - kostnadsSted
         - fagGruppe
@@ -266,7 +266,7 @@ components:
           type: string
         oppdragsId:
           type: integer
-        fagsystemId:
+        fagSystemId:
           type: string
 
     FagOmraade:

--- a/src/main/resources/openapi/oppdragsinfo-v1-swagger.yaml
+++ b/src/main/resources/openapi/oppdragsinfo-v1-swagger.yaml
@@ -864,7 +864,7 @@ components:
     Oppdrag:
       type: object
       properties:
-        fagsystemId:
+        fagSystemId:
           type: string
         oppdragsId:
           type: integer

--- a/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/api/AttestasjonApiTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/api/AttestasjonApiTest.kt
@@ -55,7 +55,7 @@ internal class AttestasjonApiTest : FunSpec({
             listOf(
                 Oppdrag(
                     ansvarsSted = "1337",
-                    fagsystemId = "123456789",
+                    fagSystemId = "123456789",
                     gjelderId = "12345678901",
                     kostnadsSted = "8128",
                     fagGruppe = "navnFaggruppe",

--- a/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/config/RequestValidationAttestasjonConfigTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/config/RequestValidationAttestasjonConfigTest.kt
@@ -36,8 +36,8 @@ class RequestValidationAttestasjonConfigTest : FunSpec({
             fagomradeResult shouldBe ValidationResult.Valid
         }
 
-        test("fagområde, fagsystemId") {
-            val fagomradeFagsystemIdResult = runBlocking { validator.validate(OppdragsRequest(kodeFagOmraade = "FAGOMRAADE", fagsystemId = "FAGSYSTEMID")) }
+        test("fagområde, fagSystemId") {
+            val fagomradeFagsystemIdResult = runBlocking { validator.validate(OppdragsRequest(kodeFagOmraade = "FAGOMRAADE", fagSystemId = "FAGSYSTEMID")) }
             fagomradeFagsystemIdResult shouldBe ValidationResult.Valid
         }
 
@@ -49,7 +49,7 @@ class RequestValidationAttestasjonConfigTest : FunSpec({
                             gjelderId = "123456789",
                             kodeFagGruppe = "faggruppe",
                             kodeFagOmraade = "kodeFagomraade",
-                            fagsystemId = "fagsystemId",
+                            fagSystemId = "fagSystemId",
                             attestert = true,
                         ),
                     )
@@ -58,18 +58,18 @@ class RequestValidationAttestasjonConfigTest : FunSpec({
             alleParametreResult shouldBe ValidationResult.Valid
         }
 
-        test("fagsystemId, uten fagområde, men med gjelderId") {
-            val fagsystemIdUtenFagomradeMedGjelderIdResult =
+        test("fagSystemId, uten fagområde, men med gjelderId") {
+            val fagSystemIdUtenFagomradeMedGjelderIdResult =
                 runBlocking {
                     validator.validate(
                         OppdragsRequest(
                             gjelderId = "123456789",
-                            fagsystemId = "fagsystemId",
+                            fagSystemId = "fagSystemId",
                         ),
                     )
                 }
 
-            fagsystemIdUtenFagomradeMedGjelderIdResult shouldBe ValidationResult.Valid
+            fagSystemIdUtenFagomradeMedGjelderIdResult shouldBe ValidationResult.Valid
         }
     }
 
@@ -100,19 +100,19 @@ class RequestValidationAttestasjonConfigTest : FunSpec({
             (faggruppeBadeAttestertOgIkkeAttestertResult as ValidationResult.Invalid).reasons.first() shouldBe ("Ugyldig kombinasjon av søkeparametere")
         }
 
-        test("fagsystemId uten fagområde") {
-            val fagsystemIdUtenFagomradeResult =
+        test("fagSystemId uten fagområde") {
+            val fagSystemIdUtenFagomradeResult =
                 runBlocking {
                     validator.validate(
                         OppdragsRequest(
-                            fagsystemId = "fagsystemId",
+                            fagSystemId = "fagSystemId",
                             kodeFagGruppe = "FAGGRUPPE",
                             attestert = null,
                         ),
                     )
                 }
 
-            (fagsystemIdUtenFagomradeResult as ValidationResult.Invalid).reasons.first() shouldBe ("Ugyldig kombinasjon av søkeparametere")
+            (fagSystemIdUtenFagomradeResult as ValidationResult.Invalid).reasons.first() shouldBe ("Ugyldig kombinasjon av søkeparametere")
         }
     }
 })

--- a/src/test/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/api/OppdragsInfoApiTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/api/OppdragsInfoApiTest.kt
@@ -68,7 +68,7 @@ internal class OppdragsInfoApiTest : FunSpec({
         val oppdragsegenskaperList =
             listOf(
                 Oppdrag(
-                    fagsystemId = "12345678901",
+                    fagSystemId = "12345678901",
                     oppdragsId = 1234556,
                     navnFagGruppe = "faggruppeNavn",
                     navnFagOmraade = "fagomraadeNavn",

--- a/src/test/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/service/OppdragsInfoServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/service/OppdragsInfoServiceTest.kt
@@ -20,7 +20,7 @@ internal class OppdragsInfoServiceTest : FunSpec({
         val oppdragList =
             listOf(
                 Oppdrag(
-                    fagsystemId = "12345678901",
+                    fagSystemId = "12345678901",
                     oppdragsId = 1234567890,
                     navnFagGruppe = "NAV Arbeid og ytelser",
                     navnFagOmraade = "Arbeidsavklaringspenger",


### PR DESCRIPTION
Det er rapportert fra testere at de får Feilmelding 400 ved søk på kun FagsystemId og fagområde