### PR TITLE
Over 1000 identer i identifiserte oppdrag

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ max_line_length = 200
 
 [*.{kt,kts}]
 ij_kotlin_imports_layout = java.**, javax.**, |, kotlin.**, kotlinx.**, |, *, |, ^, no.nav.**
+
+[**/generated/**/*]
+ktlint = disabled

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,12 +172,6 @@ tasks {
         dependsOn("openApiGenerate")
     }
 
-    ktlint {
-        filter {
-            exclude { element -> element.file.path.contains("generated/") }
-        }
-    }
-
     withType<ShadowJar>().configureEach {
         enabled = true
         archiveFileName.set("app.jar")

--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/exception/AttestasjonException.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/exception/AttestasjonException.kt
@@ -1,0 +1,3 @@
+package no.nav.sokos.oppdrag.attestasjon.exception
+
+data class AttestasjonException(override val message: String) : Exception(message)

--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
@@ -79,7 +79,11 @@ class AttestasjonService(
                 if (verifiedSkjermingForGjelderId) {
                     list.map { it.copy(erSkjermetForSaksbehandler = false) }
                 } else {
-                    val skjermingMap = skjermingService.getSkjermingForIdentListe(list.map { it.oppdragGjelderId }.distinct(), navIdent)
+                    val identer = list.map { it.oppdragGjelderId }.distinct()
+                    if (identer.size > 999) {
+                        throw IllegalArgumentException("Oppgitte søkekriterier gir for mange identer til å slå opp mot PDL (${list.size})!")
+                    }
+                    val skjermingMap = skjermingService.getSkjermingForIdentListe(identer, navIdent)
                     list.map { it.copy(erSkjermetForSaksbehandler = skjermingMap[it.oppdragGjelderId] == true) }
                 }
             }.map { it.copy(hasWriteAccess = hasSaksbehandlerWriteAccess(it, navIdent)) }

--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
@@ -14,6 +14,7 @@ import no.nav.sokos.oppdrag.attestasjon.domain.toDTO
 import no.nav.sokos.oppdrag.attestasjon.dto.OppdragDTO
 import no.nav.sokos.oppdrag.attestasjon.dto.OppdragsdetaljerDTO
 import no.nav.sokos.oppdrag.attestasjon.dto.OppdragslinjeDTO
+import no.nav.sokos.oppdrag.attestasjon.exception.AttestasjonException
 import no.nav.sokos.oppdrag.attestasjon.repository.AttestasjonRepository
 import no.nav.sokos.oppdrag.attestasjon.repository.FagomraadeRepository
 import no.nav.sokos.oppdrag.attestasjon.service.zos.ZOSConnectService
@@ -70,7 +71,7 @@ class AttestasjonService(
 
         val identer = oppdragsListe.map { it.oppdragGjelderId }.distinct()
         if (identer.size > 1000) {
-            throw IllegalArgumentException("Oppgitte søkekriterier gir for mange identer til å slå opp mot PDL (${identer.size})!")
+            throw AttestasjonException("Oppgitte søkekriterier gir for stort treff. Vennligst avgrens søket.")
         }
 
         val statusFilterOppdragList =

--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
@@ -67,6 +67,12 @@ class AttestasjonService(
             }
 
         val oppdragsListe = attestasjonRepository.getOppdrag(gjelderId, request.fagSystemId, fagomraader, request.attestertStatus.attestert, request.attestertStatus.filterEgenAttestert)
+
+        val identer = oppdragsListe.map { it.oppdragGjelderId }.distinct()
+        if (identer.size > 1000) {
+            throw IllegalArgumentException("Oppgitte søkekriterier gir for mange identer til å slå opp mot PDL (${identer.size})!")
+        }
+
         val statusFilterOppdragList =
             oppdragsListe
                 .takeIf { request.attestertStatus.filterEgenAttestert != null }
@@ -79,10 +85,6 @@ class AttestasjonService(
                 if (verifiedSkjermingForGjelderId) {
                     list.map { it.copy(erSkjermetForSaksbehandler = false) }
                 } else {
-                    val identer = list.map { it.oppdragGjelderId }.distinct()
-                    if (identer.size > 999) {
-                        throw IllegalArgumentException("Oppgitte søkekriterier gir for mange identer til å slå opp mot PDL (${list.size})!")
-                    }
                     val skjermingMap = skjermingService.getSkjermingForIdentListe(identer, navIdent)
                     list.map { it.copy(erSkjermetForSaksbehandler = skjermingMap[it.oppdragGjelderId] == true) }
                 }

--- a/src/main/kotlin/no/nav/sokos/oppdrag/config/StatusPageConfig.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/config/StatusPageConfig.kt
@@ -13,6 +13,7 @@ import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import io.ktor.server.response.respond
 
+import no.nav.sokos.oppdrag.attestasjon.exception.AttestasjonException
 import no.nav.sokos.oppdrag.attestasjon.service.zos.ZOSException
 import no.nav.sokos.oppdrag.common.exception.ForbiddenException
 import no.nav.sokos.oppdrag.integration.exception.IntegrationException
@@ -23,7 +24,7 @@ fun StatusPagesConfig.statusPageConfig() {
             when (cause) {
                 is RequestValidationException -> createApiError(HttpStatusCode.BadRequest, cause.reasons.joinToString(), call)
                 is ForbiddenException -> createApiError(HttpStatusCode.InternalServerError, cause.message, call)
-                is IntegrationException -> createApiError(HttpStatusCode.BadRequest, cause.message, call)
+                is AttestasjonException, is IntegrationException -> createApiError(HttpStatusCode.BadRequest, cause.message, call)
                 is ZOSException -> Pair(HttpStatusCode.allStatusCodes.find { it.value == cause.apiError.status }!!, cause.apiError)
                 is IllegalArgumentException -> createApiError(HttpStatusCode.BadRequest, cause.message, call)
                 else -> createApiError(HttpStatusCode.InternalServerError, cause.message ?: "En teknisk feil har oppstått. Ta kontakt med utviklerne", call)

--- a/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
@@ -28,6 +28,7 @@ import no.nav.sokos.oppdrag.attestasjon.api.model.ZosResponse
 import no.nav.sokos.oppdrag.attestasjon.domain.Oppdrag
 import no.nav.sokos.oppdrag.attestasjon.dto.OppdragsdetaljerDTO
 import no.nav.sokos.oppdrag.attestasjon.dto.OppdragslinjeDTO
+import no.nav.sokos.oppdrag.attestasjon.exception.AttestasjonException
 import no.nav.sokos.oppdrag.attestasjon.service.zos.ZOSConnectService
 import no.nav.sokos.oppdrag.common.GRUPPE_ATTESTASJON_NASJONALT_READ
 import no.nav.sokos.oppdrag.common.GRUPPE_ATTESTASJON_NASJONALT_WRITE
@@ -299,7 +300,7 @@ internal class AttestasjonServiceTest :
                 AssertionError("getSkjermingForIdentListe should not be called for more than 1000 idents")
 
             val exception =
-                shouldThrow<IllegalArgumentException> {
+                shouldThrow<AttestasjonException> {
                     attestasjonService.getOppdrag(
                         OppdragsRequest(
                             gjelderId = null,
@@ -312,7 +313,7 @@ internal class AttestasjonServiceTest :
                     )
                 }
 
-            exception.message shouldBe "Oppgitte søkekriterier gir for mange identer til å slå opp mot PDL (1001)!"
+            exception.message shouldBe "Oppgitte søkekriterier gir for stort treff. Vennligst avgrens søket."
         }
 
         test("getOppdragsdetaljer returnerer tom liste for et gitt oppdrag som ikke har attestasjonslinjer") {

--- a/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
@@ -276,17 +276,17 @@ internal class AttestasjonServiceTest :
             exception.message shouldBe "Mangler rettigheter til å se informasjon!"
         }
 
-        test("hent oppdrag kaster exception hvis det er over 999 forskjellige identer i identifiserte oppdrag") {
+        test("hent oppdrag kaster exception hvis det er over 1000 forskjellige identer i identifiserte oppdrag") {
             val navIdent = navIdent.copy(roller = listOf(GRUPPE_ATTESTASJON_NOS_READ))
 
             coEvery { attestasjonRepository.getOppdrag(any(), any(), any(), any(), any()) } returns
-                List(1000) {
+                List(1001) {
                     Oppdrag(
                         antAttestanter = 1,
                         navnFaggruppe = "HELSETJENESTER FRIKORT TAK 1 OG 2",
                         navnFagomraade = "Egenandelsrefusjon frikort tak 1",
                         fagSystemId = it.toString(),
-                        oppdragGjelderId = GJELDER_ID + it,
+                        oppdragGjelderId = GJELDER_ID.dropLast(4) + String.format("%04d", it),
                         kodeFaggruppe = "FRIKORT",
                         kodeFagomraade = "FRIKORT1",
                         kostnadssted = ENHETSNUMMER_NOS,
@@ -296,7 +296,7 @@ internal class AttestasjonServiceTest :
                 }
 
             coEvery { skjermingService.getSkjermingForIdentListe(any(), any()) } throws
-                AssertionError("getSkjermingForIdentListe should not be called for more than 999 idents")
+                AssertionError("getSkjermingForIdentListe should not be called for more than 1000 idents")
 
             val exception =
                 shouldThrow<IllegalArgumentException> {
@@ -312,7 +312,7 @@ internal class AttestasjonServiceTest :
                     )
                 }
 
-            exception.message shouldBe "Oppgitte søkekriterier gir for mange identer til å slå opp mot PDL (1000)!"
+            exception.message shouldBe "Oppgitte søkekriterier gir for mange identer til å slå opp mot PDL (1001)!"
         }
 
         test("getOppdragsdetaljer returnerer tom liste for et gitt oppdrag som ikke har attestasjonslinjer") {

--- a/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
@@ -276,7 +276,7 @@ internal class AttestasjonServiceTest :
             exception.message shouldBe "Mangler rettigheter til å se informasjon!"
         }
 
-        test("hent oppdrag should throw exception when there are over 999 oppdrags") {
+        test("hent oppdrag kaster exception hvis det er over 999 forskjellige identer i identifiserte oppdrag") {
             val navIdent = navIdent.copy(roller = listOf(GRUPPE_ATTESTASJON_NOS_READ))
 
             coEvery { attestasjonRepository.getOppdrag(any(), any(), any(), any(), any()) } returns

--- a/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
@@ -286,7 +286,7 @@ internal class AttestasjonServiceTest :
                         navnFaggruppe = "HELSETJENESTER FRIKORT TAK 1 OG 2",
                         navnFagomraade = "Egenandelsrefusjon frikort tak 1",
                         fagSystemId = it.toString(),
-                        oppdragGjelderId = GJELDER_ID,
+                        oppdragGjelderId = GJELDER_ID + it,
                         kodeFaggruppe = "FRIKORT",
                         kodeFagomraade = "FRIKORT1",
                         kostnadssted = ENHETSNUMMER_NOS,
@@ -312,7 +312,7 @@ internal class AttestasjonServiceTest :
                     )
                 }
 
-            exception.message shouldBe "For mange treff eller noe sånt"
+            exception.message shouldBe "Oppgitte søkekriterier gir for mange identer til å slå opp mot PDL (1000)!"
         }
 
         test("getOppdragsdetaljer returnerer tom liste for et gitt oppdrag som ikke har attestasjonslinjer") {

--- a/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
@@ -279,9 +279,6 @@ internal class AttestasjonServiceTest :
         test("hent oppdrag should throw exception when there are over 999 oppdrags") {
             val navIdent = navIdent.copy(roller = listOf(GRUPPE_ATTESTASJON_NOS_READ))
 
-            // TODO: Remove this mock when the test is green
-            coEvery { skjermingService.getSkjermingForIdentListe(any(), any()) } returns emptyMap()
-
             coEvery { attestasjonRepository.getOppdrag(any(), any(), any(), any(), any()) } returns
                 List(1000) {
                     Oppdrag(
@@ -298,6 +295,9 @@ internal class AttestasjonServiceTest :
                     )
                 }
 
+            coEvery { skjermingService.getSkjermingForIdentListe(any(), any()) } throws
+                AssertionError("getSkjermingForIdentListe should not be called for more than 999 idents")
+
             val exception =
                 shouldThrow<IllegalArgumentException> {
                     attestasjonService.getOppdrag(
@@ -312,10 +312,7 @@ internal class AttestasjonServiceTest :
                     )
                 }
 
-            // TODO: Replace with proper exception message
             exception.message shouldBe "For mange treff eller noe sånt"
-
-            coVerify(exactly = 0) { skjermingService.getSkjermingForIdentListe(any(), any()) }
         }
 
         test("getOppdragsdetaljer returnerer tom liste for et gitt oppdrag som ikke har attestasjonslinjer") {


### PR DESCRIPTION
# Beskrivelse

https://jira.adeo.no/browse/TOB-4580
Problem: PDL bulk godkjenner ikke kall på over 1000 identer om gangen.
Løsning: Vi godkjenner ikke søk hvor man treffer 1000 eller flere identer. Da kaller vi ikke PDL og viser en feilmelding istedenfor.


# Sjekkliste:

- [x] Koden følger teamets retningslinjer for kodestil
- [x] Navn på variabler i domeneklasser/objekter matcher databasemodellene og kolonner
- [x] Jeg har brukt norsk for fagbegreper og engelsk for generell kodeterminologi
- [x] Jeg har lagt til tester for koden 
- [x] Jeg har oppdatert dokumentasjon der det er relevant (Swagger, README etc.)
