### PR TITLE
Legg til filtrering på enhet ved søk i Oppdragsinfo

### DIFF
--- a/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonService.kt
@@ -142,7 +142,7 @@ class AttestasjonService(
             ),
         )
 
-        if (!saksbehandler.hasAccessToAnyAdGroup(AdGroup.ATTESTASJON_NASJONALT_WRITE, AdGroup.ATTESTASJON_NOS_WRITE, AdGroup.ATTESTASJON_NOP_WRITE)) {
+        if (!saksbehandler.hasAdGroupAccess(AdGroup.ATTESTASJON_NASJONALT_WRITE, AdGroup.ATTESTASJON_NOS_WRITE, AdGroup.ATTESTASJON_NOP_WRITE)) {
             return ZosResponse(
                 errorMessage = "Mangler rettigheter til å attestere oppdrag!",
             )

--- a/src/main/kotlin/no/nav/sokos/oppdrag/common/NavIdent.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/common/NavIdent.kt
@@ -6,9 +6,7 @@ data class NavIdent(
     val ident: String,
     val roller: List<String> = emptyList(),
 ) {
-    fun hasAdGroupAccess(adGroup: AdGroup): Boolean = adGroup.adGroupName in roller
-
-    fun hasAccessToAnyAdGroup(vararg adGroups: AdGroup): Boolean = adGroups.any { it.adGroupName in roller }
+    fun hasAdGroupAccess(vararg adGroups: AdGroup): Boolean = adGroups.any { it.adGroupName in roller }
 
     fun hasAccessFortrolig(): Boolean = AdGroup.FORTROLIG.adGroupName in roller
 

--- a/src/main/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/domain/Oppdrag.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/domain/Oppdrag.kt
@@ -11,4 +11,6 @@ data class Oppdrag(
     val kjorIdag: String,
     val typeBilag: String? = null,
     val kodeStatus: String,
+    val kostnadssted: String? = null,
+    val ansvarssted: String? = null,
 )

--- a/src/main/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/repository/OppdragRepository.kt
+++ b/src/main/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/repository/OppdragRepository.kt
@@ -33,7 +33,29 @@ class OppdragRepository(
                     OP.KJOR_IDAG,
                     TRIM(OP.TYPE_BILAG) AS TYPE_BILAG,
                     TRIM(FG.NAVN_FAGGRUPPE) AS NAVN_FAGGRUPPE,
-                    OS.KODE_STATUS
+                    OS.KODE_STATUS,
+                    TRIM((SELECT OK.ENHET
+                    FROM T_OPPDRAGSENHET OK
+                    WHERE OK.OPPDRAGS_ID = OP.OPPDRAGS_ID
+                    AND OK.TYPE_ENHET = 'BOS'
+                    AND OK.TIDSPKT_REG = (
+                        SELECT MAX(TIDSPKT_REG)
+                        FROM T_OPPDRAGSENHET OK2
+                        WHERE OK2.OPPDRAGS_ID = OK.OPPDRAGS_ID
+                        AND OK2.TYPE_ENHET = OK.TYPE_ENHET
+                        AND OK2.DATO_FOM <= CURRENT DATE)
+                )) AS KOSTNADSSTED,
+                TRIM((SELECT OA.ENHET
+                    FROM T_OPPDRAGSENHET OA
+                    WHERE OA.OPPDRAGS_ID = OP.OPPDRAGS_ID
+                    AND OA.TYPE_ENHET = 'BEH'
+                    AND OA.TIDSPKT_REG = (
+                        SELECT MAX(TIDSPKT_REG)
+                        FROM T_OPPDRAGSENHET OA2
+                        WHERE OA2.OPPDRAGS_ID = OA.OPPDRAGS_ID
+                        AND OA2.TYPE_ENHET = OA.TYPE_ENHET
+                        AND OA2.DATO_FOM <= CURRENT DATE)
+                )) AS ANSVARSSTED
                 FROM T_OPPDRAG OP,
                     T_FAGOMRAADE FO, 
                     T_FAGGRUPPE FG,
@@ -349,6 +371,8 @@ class OppdragRepository(
             kjorIdag = row.string("KJOR_IDAG"),
             typeBilag = row.string("TYPE_BILAG"),
             kodeStatus = row.string("KODE_STATUS"),
+            kostnadssted = row.stringOrNull("KOSTNADSSTED"),
+            ansvarssted = row.stringOrNull("ANSVARSSTED"),
         )
     }
 

--- a/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/attestasjon/service/AttestasjonServiceTest.kt
@@ -135,7 +135,7 @@ internal class AttestasjonServiceTest :
             }
         }
 
-        test("hent opopdrag for en gjelderId når saksbehandler har bare lesetilgang til NOS") {
+        test("hent oppdrag for en gjelderId når saksbehandler har bare lesetilgang til NOS") {
             Db2Listener.dataSource.transaction { session ->
                 session.update(queryOf("database/attestasjon/getOppdrag.sql".readFromResource())) shouldBeGreaterThan 0
             }
@@ -156,7 +156,7 @@ internal class AttestasjonServiceTest :
             coVerify(exactly = 0) { skjermingService.getSkjermingForIdentListe(any(), any()) }
         }
 
-        test("hent opopdrag for en gjelderId når saksbehandler har både lesetilgang og skrivetilgang til NOS") {
+        test("hent oppdrag for en gjelderId når saksbehandler har både lesetilgang og skrivetilgang til NOS") {
             Db2Listener.dataSource.transaction { session ->
                 session.update(queryOf("database/attestasjon/getOppdrag.sql".readFromResource())) shouldBeGreaterThan 0
             }
@@ -232,7 +232,7 @@ internal class AttestasjonServiceTest :
             coVerify(exactly = 0) { skjermingService.getSkjermingForIdentListe(any(), any()) }
         }
 
-        test("hent opopdrag for en gjelderId når saksbehandler har bare lesetilgang og skrivetilgang til Nasjonalt") {
+        test("hent oppdrag for en gjelderId når saksbehandler har bare lesetilgang og skrivetilgang til Nasjonalt") {
             Db2Listener.dataSource.transaction { session ->
                 session.update(queryOf("database/attestasjon/getOppdrag.sql".readFromResource())) shouldBeGreaterThan 0
             }

--- a/src/test/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/service/OppdragsInfoServiceTest.kt
+++ b/src/test/kotlin/no/nav/sokos/oppdrag/oppdragsinfo/service/OppdragsInfoServiceTest.kt
@@ -390,21 +390,21 @@ internal class OppdragsInfoServiceTest :
 
             val navIdentNOS = NavIdent("bruker2", listOf(AdGroup.OPPDRAGSINFO_NOS_READ.adGroupName))
             val resultNOS = oppdragsInfoService.getOppdrag("24029428499", null, navIdentNOS)
-            resultNOS.data.forEach { oppdrag ->
+            resultNOS.data.all { oppdrag ->
                 (
                     oppdrag.ansvarssted == ENHETSNUMMER_NOS ||
                         (oppdrag.ansvarssted == null && oppdrag.kostnadssted == ENHETSNUMMER_NOS)
-                ) shouldBe true
-            }
+                )
+            } shouldBe true
 
             val navIdentNOP = NavIdent("bruker3", listOf(AdGroup.OPPDRAGSINFO_NOP_READ.adGroupName))
             val resultNOP = oppdragsInfoService.getOppdrag("24029428499", null, navIdentNOP)
-            resultNOP.data.forEach { oppdrag ->
+            resultNOP.data.all { oppdrag ->
                 (
                     oppdrag.ansvarssted == ENHETSNUMMER_NOP ||
                         (oppdrag.ansvarssted == null && oppdrag.kostnadssted == ENHETSNUMMER_NOP)
-                ) shouldBe true
-            }
+                )
+            } shouldBe true
 
             val navIdentNoAccess = NavIdent("bruker4", emptyList())
             val resultNoAccess = oppdragsInfoService.getOppdrag("24029428499", null, navIdentNoAccess)


### PR DESCRIPTION
# Beskrivelse

Beriker Oppdrag-klassen med kostnadssted og ansvarssted og filtrerer basert på saksbehandlers gruppetilgang.

# Sjekkliste:

- [x] Koden følger teamets retningslinjer for kodestil
- [x] Navn på variabler i domeneklasser/objekter matcher databasemodellene og kolonner
- [x] Jeg har brukt norsk for fagbegreper og engelsk for generell kodeterminologi
- [x] Jeg har lagt til tester for koden 
- [x] Jeg har oppdatert dokumentasjon der det er relevant (Swagger, README etc.)
