### PR TITLE
Fix netty-handler vulnerability (CVE-2026-44249, CVE-2026-45416)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,8 +177,8 @@ configurations.all {
                 because("jackson-core: Number Length Constraint Bypass in Async Parser Leads to Potential DoS Condition. Affected version >= 2.19.0, < 2.21.1")
             }
             if (requested.group == "io.netty") {
-                useVersion("4.2.13.Final")
-                because("Align Netty to 4.2.13.Final due to CVE-2026-42579")
+                useVersion("4.2.15.Final")
+                because("Resolves production Dependabot alerts CVE-2026-44249 and CVE-2026-45416")
             }
             if (requested.group == "org.bouncycastle" && requested.name == "bcprov-jdk18on") {
                 useVersion("1.84")


### PR DESCRIPTION
## Summary

Updates the Netty resolution strategy to enforce version 4.2.15.Final across all Netty modules in production configurations.

## Changes

- Updated resolutionStrategy for `io.netty` group from 4.2.13.Final to 4.2.15.Final
- Updated reason string to reference both CVE-2026-44249 and CVE-2026-45416

## Verification

✅ All Netty modules (handler, buffer, codec-http, codec-http2, resolver-dns, transport) resolve to 4.2.15.Final in runtimeClasspath  
✅ Build successful  
✅ All tests passed (175+ tests)  
✅ Dependency verification confirmed via `./gradlew dependencyInsight`

## Production Configuration

The updated resolution strategy applies to:
- io.netty:netty-handler:4.2.15.Final
- io.netty:netty-buffer:4.2.15.Final
- io.netty:netty-codec-http:4.2.15.Final
- io.netty:netty-codec-http2:4.2.15.Final
- io.netty:netty-resolver-dns:4.2.15.Final
- io.netty:netty-transport:4.2.15.Final
- And all related Netty modules

The resolution overrides requests from:
- Ktor (requested 4.2.12.Final)
- Lettuce (requested 4.2.5.Final)